### PR TITLE
Sharp version change

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ndarray-ops": "^1.2.2",
     "typedarray-pool": "^1.1.0",
     "lodash": "^4.11.1",
-    "sharp": "^0.16.0"
+    "sharp": "^0.17.0"
   },
   "devDependencies": {
     "browserify-shim": "^3.8.12",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ndarray-ops": "^1.2.2",
     "typedarray-pool": "^1.1.0",
     "lodash": "^4.11.1",
-    "sharp": "~0.16.0"
+    "sharp": "^0.16.0"
   },
   "devDependencies": {
     "browserify-shim": "^3.8.12",


### PR DESCRIPTION
An error on trying to install numjs was caused by sharp@0.16.2. Changing to a more recent version of Sharp (sharp@0.17.3) fixed the issue.