### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ bower install numjs
 
 ```html
 <script src="bower_packages/numjs/dist/numjs.min.js"></script>
+<!-- or include it directly from a CDN -->
+<script src="https://cdn.jsdelivr.net/gh/nicolaspanel/numjs@0.15.1/dist/numjs.min.js"></script>
 ```
-
 
 ## Basics
 


### PR DESCRIPTION
I added a [jsDelivr CDN](https://www.jsdelivr.com/package/npm/numjs) link to your readme to make it easier to use.
Fixes #39