### PR TITLE
Added mean calculation over axis

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -793,10 +793,12 @@ function rot90 (m, k, axes) {
 }
 
 /**
- * Calculates the arithmetic mean over a specific axis
+ * Calculates the arithmetic mean over a specific axis.
  * axis := 0 means x-axis (columns)
  * axis := 1 means y-axis (rows)
  * @param {NdArray} arr 
+ *  Must be a square matrices or a simple vector.
+ *  If arr is a vector it uses the function mean(...)
  * @param {Integer} axis (0 or 1)
  */
 function meanaxis(arr, axis) {

--- a/src/index.js
+++ b/src/index.js
@@ -823,7 +823,7 @@ function meanaxis(arr, axis = 0) {
     }
   }
 
-  return new NdArray(results);
+  return NdArray.new(results);
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -792,6 +792,40 @@ function rot90 (m, k, axes) {
   }
 }
 
+/**
+ * Calculates the arithmetic mean over a specific axis
+ * axis := 0 means x-axis (columns)
+ * axis := 1 means y-axis (rows)
+ * @param {NdArray} arr 
+ * @param {Integer} axis (0 or 1)
+ */
+function meanAxis(arr, axis = 0) {
+
+  // precondition
+  if (axis < 0 || axis >= 2) {
+    throw new errors.ValueError("Axis must be 0 or 1");
+  }
+
+  if (arr.shape[0] != arr.shape[1]) {
+    throw new errors.ValueError("The array must be a square array.");
+  }
+
+  const shape = arr.shape;
+  let results = [];
+
+  if (axis == 0) {
+    for (let i = 0; i < shape[0]; i++) {
+      results.push(mean(arr.pick(null, i)));
+    }
+  } else {
+    for (let i = 0; i < shape.length; i++) {
+      results.push(mean(arr.pick(i)));
+    }
+  }
+
+  return new NdArray(results);
+}
+
 module.exports = {
   config: CONF,
   dtypes: DTYPES,

--- a/src/index.js
+++ b/src/index.js
@@ -799,27 +799,31 @@ function rot90 (m, k, axes) {
  * @param {NdArray} arr 
  * @param {Integer} axis (0 or 1)
  */
-function meanaxis(arr, axis = 0) {
+function meanaxis(arr, axis) {
 
   // precondition
   if (axis < 0 || axis >= 2) {
     throw new errors.ValueError("Axis must be 0 or 1");
   }
 
-  if (arr.shape[0] != arr.shape[1]) {
+  if (arr.shape[0] != arr.shape[1] && arr.shape.length >= 2) {
     throw new errors.ValueError("The array must be a square array.");
   }
 
   const shape = arr.shape;
   let results = [];
 
-  if (axis == 0) {
-    for (let i = 0; i < shape[0]; i++) {
-      results.push(mean(arr.pick(null, i)));
-    }
-  } else {
-    for (let i = 0; i < shape.length; i++) {
-      results.push(mean(arr.pick(i)));
+  if (arr.shape.length == 1) { // for simple vectors
+    return mean(arr);
+  } else { // for matrices
+    if (axis == 0) {
+      for (let i = 0; i < shape[0]; i++) {
+        results.push(mean(arr.pick(null, i)));
+      }
+    } else {
+      for (let i = 0; i < shape.length; i++) {
+        results.push(mean(arr.pick(i)));
+      }
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -883,6 +883,7 @@ module.exports = {
   identity: identity,
   stack: stack,
   rot90: rot90,
+  meanAxis: meanAxis,
   int8: function (array) { return NdArray.new(array, 'int8'); },
   uint8: function (array) { return NdArray.new(array, 'uint8'); },
   int16: function (array) { return NdArray.new(array, 'int16'); },

--- a/src/index.js
+++ b/src/index.js
@@ -799,7 +799,7 @@ function rot90 (m, k, axes) {
  * @param {NdArray} arr 
  * @param {Integer} axis (0 or 1)
  */
-function meanAxis(arr, axis = 0) {
+function meanaxis(arr, axis = 0) {
 
   // precondition
   if (axis < 0 || axis >= 2) {
@@ -883,7 +883,7 @@ module.exports = {
   identity: identity,
   stack: stack,
   rot90: rot90,
-  meanAxis: meanAxis,
+  meanaxis: meanaxis,
   int8: function (array) { return NdArray.new(array, 'int8'); },
   uint8: function (array) { return NdArray.new(array, 'uint8'); },
   int16: function (array) { return NdArray.new(array, 'int16'); },

--- a/test/mocha/meanaxis.spec.js
+++ b/test/mocha/meanaxis.spec.js
@@ -1,0 +1,16 @@
+/* eslint-env mocha */
+'use strict';
+
+var expect = require('expect.js');
+
+var nj = require('../../src');
+
+describe('meanaxis', function () {
+    it('should work on square matrices', function () {
+      var x = nj.array([[1, 2],[3, 4]]);
+      expect(nj.meanaxis(x, 0).tolist())
+        .to.eql([2, 3]);
+      expect(nj.meanaxis(x, 1).tolist())
+        .to.eql([1.5, 3.5]);
+    });
+  });

--- a/test/mocha/meanaxis.spec.js
+++ b/test/mocha/meanaxis.spec.js
@@ -8,9 +8,11 @@ var nj = require('../../src');
 describe('meanaxis', function () {
     it('should work on square matrices', function () {
       var x = nj.array([[1, 2],[3, 4]]);
+      var y = nj.array([1, 2, 3]);
       expect(nj.meanaxis(x, 0).tolist())
         .to.eql([2, 3]);
       expect(nj.meanaxis(x, 1).tolist())
         .to.eql([1.5, 3.5]);
+      expect(nj.meanaxis(y, 0)).to.equal(2.0);
     });
   });


### PR DESCRIPTION
Issue #54 
* I added a function  
```js
/**
 * Calculates the arithmetic mean over a specific axis.
 * axis := 0 means x-axis (columns)
 * axis := 1 means y-axis (rows)
 * @param {NdArray} arr 
 *  Must be a square matrices or a simple vector.
 *  If arr is a vector it uses the function mean(...)
 * @param {Integer} axis (0 or 1)
 */
function meanaxis(arr, axis)
```

* I added tests ```meanaxis.spec.js```. The tests run correctly