### PR TITLE
Adding addScalarMultiple operation

### DIFF
--- a/src/ndarray.js
+++ b/src/ndarray.js
@@ -426,6 +426,37 @@ NdArray.prototype.subtract = function (x, copy) {
   return arr;
 };
 
+var addScalarMult = cwise({
+  args: ["array", "array", "scalar"],
+  body: function(a, b, s) {
+    a += (s*b);
+  }
+})
+
+/**
+* Add `a` * `x` to the array, element-wise.
+*
+* @param {(NdArray|Array)} x
+* @param {number} a
+* @param {boolean} [copy=true]
+* @returns {NdArray}
+*/
+NdArray.prototype.addScalarMultiple = function (x, a, copy) {
+  if (arguments.length === 1) {
+    copy = true;
+  }
+
+  if (_.isNumber(x)) {
+    throw new errors.ValueError('cannot add scalar multiple of a scalar value, use add instead.');
+  }
+
+  var arr = copy ? this.clone() : this;
+
+  x = createArray(x, this.dtype);
+  addScalarMult(arr.selection, x.selection, a);
+  return arr;
+};
+
 /**
 * Multiply array by `x`, element-wise.
 *


### PR DESCRIPTION
Hey,

I frequently need the operation ```X = X + b * A```, where `X` and `A` are matrices, and `b` is a scalar value. With the available operations, the only way for me to do this and leave A's values unchanged is by using ```X.add(A.multiply(b, true), false)```.  This results in an unnecessary cloning operation on `A`.   

I wrote a `cwise` operation in this pull request that computes the above without any unnecessary cloning. It increased the FPS on one of my projects dramatically, so maybe it will be of help to others:) 