### PR TITLE
Fix typo np --> nj in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,10 +520,10 @@ array([[  0,  1,  2,  3],
 > a = nj.array([1, 2, 3])
 > b = nj.array([2, 3, 4])
 
-> np.stack([a, b])
+> nj.stack([a, b])
 array([[1, 2, 3],
        [2, 3, 4]])
-> np.stack([a, b], -1)
+> nj.stack([a, b], -1)
 array([[1, 2],
        [2, 3],
        [3, 4]])


### PR DESCRIPTION
Cool project! Thanks for making this for the JavaScript ecosystem. I noticed a small typo in the `README.md`, I think.

BTW is there an easy way to create a `nj.NdArray` from a `nj.ndarray` (which is just an alias for `ndarray`)? I ask because I've written a library for reading the [zarr format](https://github.com/manzt/zarrita.js), and I'd like to suggest others try out numjs for working with strided TypedArray buffers.

```javascript
const { data, shape, stride } = await z_array.get(null); // data is a strided typed array
// solution I've currently found ...
const arr = nj.array();
arr.selection = nj.ndarray(data, shape, stride); // mutate inner selection object which is just ndarray
```

example: https://observablehq.com/d/7156b4838eed011d